### PR TITLE
Drop Go 1.23 Support And Update Dependencies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ["1.23", "1.24"]
+        go-version: ["1.24"]
         os: ["ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: ["1.23", "1.24"]
+        go-version: ["1.24"]
         os: ["ubuntu-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/**/*.local.md
+/**/*.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Go package providing an `slog.Handler` implementation for AWS Lambda functions with advanced logging controls. The package automatically configures log format (JSON/text) and level based on AWS Lambda environment variables.
+
+## Commands
+
+### Testing
+- `make test` - Run all tests with race detection
+- `go test -v -race ./...` - Run tests directly
+- `go test -coverprofile=coverage.txt ./...` - Generate coverage report
+
+### Benchmarking
+- `make benchmark` - Run benchmarks for 10 seconds with memory stats
+
+### Building
+- `go build ./...` - Build the package
+
+### Code Quality
+- `gofmt -s -l .` - Check formatting (must have zero output)
+- `nilaway ./...` - Run nil safety analysis
+- `gosec ./...` - Run security scanning
+- `govulncheck ./...` - Check for vulnerabilities
+
+## Architecture
+
+The core handler is in `handler.go` with these key components:
+
+- **Handler struct** - Main slog handler implementation that outputs to io.Writer
+- **Environment-based configuration** - Uses AWS Lambda env vars:
+  - `AWS_LAMBDA_LOG_LEVEL` (TRACE/DEBUG/INFO/WARN/ERROR/FATAL)
+  - `AWS_LAMBDA_LOG_FORMAT` (json/text)
+  - `AWS_LAMBDA_FUNCTION_NAME` and `AWS_LAMBDA_FUNCTION_VERSION`
+- **Lambda context integration** - Extracts request ID from lambda context
+- **Buffering** - Uses sync.Pool for efficient buffer management
+- **Custom log levels** - Maps AWS Lambda levels to slog levels with TRACE and FATAL extensions
+
+The handler outputs structured logs with AWS Lambda metadata including function name, version, and request ID when available.
+
+## Testing Strategy
+
+- Tests are split between external (`handler_test.go`) and internal (`handler_internal_test.go`)
+- Example usage in `example_test.go`
+- Memory leak testing with `go.uber.org/goleak`
+- Race condition testing enabled by default

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/maddiesch/slog-lambda
 
-go 1.23.0
+go 1.24.0
+
+toolchain go1.24.4
 
 require (
-	github.com/aws/aws-lambda-go v1.48.0
+	github.com/aws/aws-lambda-go v1.49.0
 	github.com/stretchr/testify v1.8.0
 	go.uber.org/goleak v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-lambda-go v1.48.0 h1:1aZUYsrJu0yo5fC4z+Rba1KhNImXcJcvHu763BxoyIo=
-github.com/aws/aws-lambda-go v1.48.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/aws/aws-lambda-go v1.49.0 h1:z4VhTqkFZPM3xpEtTqWqRqsRH4TZBMJqTkRiBPYLqIQ=
+github.com/aws/aws-lambda-go v1.49.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Summary

This PR drops support for Go 1.23 and requires Go 1.24 as the minimum version. The change updates the toolchain, dependencies, and CI workflow to test only Go 1.24. Additionally, it adds development documentation for Claude Code assistance.

## Changes
- Updated `go.mod` to require Go 1.24.0 with toolchain go1.24.4
- Updated `aws-lambda-go` from v1.48.0 to v1.49.0 
- Modified GitHub Actions workflow to test only Go 1.24
- Added `CLAUDE.md` with development commands and architecture overview
- Added `.gitignore` for local development files

## Test plan
- [x] CI tests pass with Go 1.24
- [x] Dependencies updated successfully
- [x] Build and test commands work locally

🤖 Generated with [Claude Code](https://claude.ai/code)