### PR TITLE
fix slog.Group type and never panic for failing logs

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -431,8 +431,18 @@ func normalizeValue(v slog.Value) any {
 		return normalizeValue(v.Resolve())
 	case slog.KindAny:
 		return normalizeAnyValue(v.Any())
+	case slog.KindGroup:
+		attrs := v.Group()
+		if len(attrs) == 0 {
+			return nil
+		}
+		rec := make(logRecord, len(attrs))
+		for _, a := range attrs {
+			rec.append(a)
+		}
+		return rec
 	default:
-		panic(fmt.Sprintf("bad kind: %s", v.Kind()))
+		return v.String()
 	}
 }
 

--- a/handler_internal_test.go
+++ b/handler_internal_test.go
@@ -201,6 +201,43 @@ func Test_normalizeValue(t *testing.T) {
 			})
 		})
 	})
+
+	t.Run("slog.KindGroup", func(t *testing.T) {
+		t.Run("non-empty group", func(t *testing.T) {
+			v := slog.GroupValue(slog.String("key", "value"), slog.Int("num", 42))
+			result := normalizeValue(v)
+			rec, ok := result.(logRecord)
+			require.True(t, ok, "expected logRecord")
+			assert.Equal(t, "value", rec["key"])
+			assert.Equal(t, int64(42), rec["num"])
+		})
+
+		t.Run("empty group", func(t *testing.T) {
+			v := slog.GroupValue()
+			assert.Nil(t, normalizeValue(v))
+		})
+	})
+
+	t.Run("LogValuer resolving to group", func(t *testing.T) {
+		v := slog.AnyValue(groupLogValuer{})
+		result := normalizeValue(v)
+		rec, ok := result.(logRecord)
+		require.True(t, ok, "expected logRecord")
+		assert.Equal(t, "bar", rec["foo"])
+	})
+
+	t.Run("unknown kind returns string", func(t *testing.T) {
+		// Verify default case doesn't panic
+		assert.NotPanics(t, func() {
+			normalizeValue(slog.Value{})
+		})
+	})
+}
+
+type groupLogValuer struct{}
+
+func (groupLogValuer) LogValue() slog.Value {
+	return slog.GroupValue(slog.String("foo", "bar"))
 }
 
 type jsonMarshalerSuccess struct{}

--- a/value_test.go
+++ b/value_test.go
@@ -55,6 +55,26 @@ func TestValueTypes(t *testing.T) {
 			assert.Contains(t, buffer.String(), `group.value="Foo Bar"`)
 		})
 	})
+
+	t.Run("LogValuer resolving to group", func(t *testing.T) {
+		t.Run("top level attr", func(t *testing.T) {
+			logger := slog.New(newHandler(t))
+			logger.InfoContext(t.Context(), t.Name(), "value", groupTestLogValuer{})
+			assert.Contains(t, buffer.String(), `value.foo="bar"`)
+		})
+
+		t.Run("group level attr", func(t *testing.T) {
+			logger := slog.New(newHandler(t))
+			logger.InfoContext(t.Context(), t.Name(), slog.Group("group", "value", groupTestLogValuer{}))
+			assert.Contains(t, buffer.String(), `group.value.foo="bar"`)
+		})
+	})
+}
+
+type groupTestLogValuer struct{}
+
+func (groupTestLogValuer) LogValue() slog.Value {
+	return slog.GroupValue(slog.String("foo", "bar"), slog.Int("num", 42))
 }
 
 type nestedTestLogValuer struct {


### PR DESCRIPTION
Seeing a bunch of this

```
panic: bad kind: Group
```

This adds `slog.KindGroup` to the list and no longer panics in the default case.